### PR TITLE
Add CI/CD pipeline

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,17 +12,17 @@ jobs:
     timeout-minutes: 10
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Install npm dependencies
-      run: npm install
+      - name: Install npm dependencies
+        run: npm install
 
-    - name: Run automated release process with semantic-release
-      if: github.event_name == 'push'
-      uses: cycjimmy/semantic-release-action@v2
-      with:
-        extra_plugins: |
-          @semantic-release/changelog
-      env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Run automated release process with semantic-release
+        if: github.event_name == 'push'
+        uses: cycjimmy/semantic-release-action@v2
+        with:
+          extra_plugins: |
+            @semantic-release/changelog
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    if: "!contains(github.event.commits[0].message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install npm dependencies
+      run: npm install
+
+    - name: Run automated release process with semantic-release
+      if: github.event_name == 'push'
+      uses: cycjimmy/semantic-release-action@v2
+      with:
+        extra_plugins: |
+          @semantic-release/changelog
+      env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Add release through GH Actions and semantic-release. This action add: 
* Create a new release on the repo 
* Add changelog based on the commit messages
* Publish module to NPM 

This pipeline makes use of https://github.com/cycjimmy/semantic-release-action, which, in turn, is based on https://github.com/semantic-release/semantic-release. 

The action is triggered every time a push is made on `main` branch (e.g. as result of a PR merge). The action scans the commit(s) and looks for the following keywords in the commit message: 

* `fix`: will create a new patch release
* `feat`: will create a new minor release 
* `breaking`: will create a new major release 
(A full list of keywords can be found [here](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js)) 

The commit message should follow [Angular Commit Message Conventions](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-format), so for example a minor release commit for the `utils` module will look like the following: 

```
feat(utils): This is my new awesome feature!

Remember, with great power come great responsibility
```

If the commit isn't supposed to trigger a release, then other keyword (such as `chore`, or `doc`) can be used. 

This action also include the @semantic-release/changelog which automatically create a changelog that is added as description for the release on the repo. 
