### PR TITLE
Feature: added option to use the --yes flag in deploy and destroy

### DIFF
--- a/src/commands/infra/deploy.js
+++ b/src/commands/infra/deploy.js
@@ -1,6 +1,6 @@
 const { TwilioClientCommand } = require('@twilio/cli-core').baseCommands;
 const { TwilioCliError } = require('@twilio/cli-core').services.error;
-const { flags } = require("@oclif/command");
+const { flags } = require('@oclif/command');
 
 const { addInfra } = require('../../infra');
 
@@ -19,11 +19,13 @@ class InfraDeploy extends TwilioClientCommand {
         `The current stack is already deployed to ${deployment}. Please switch to that profile or define a new environment`
       );
     }
+
     let command = ['up'];
-    if (this.flags.yes) {
+    if (this.flags['non-interactive']) {
       command.push("--yes");
     }
     runPulumiCommand(command, true, this.twilioClient);
+
     try {
       // Store account SID of the project used for deployment
       addInfra(this.twilioClient.accountSid, getPulumiStack(), true);
@@ -35,12 +37,12 @@ class InfraDeploy extends TwilioClientCommand {
 
 InfraDeploy.flags = Object.assign(
   {
-    yes: flags.boolean({
-      char: 'y',
-      description: 'Passes through the --yes option to pulumi. Deploys without interactive confirmation.'
+    'non-interactive': flags.boolean({
+      char: 'n',
+      description: 'Deploys without interactive confirmation.',
     })
   },
-  TwilioClientCommand.flags
+  TwilioClientCommand.flags,
 );
 
 InfraDeploy.description =

--- a/src/commands/infra/deploy.js
+++ b/src/commands/infra/deploy.js
@@ -1,5 +1,6 @@
 const { TwilioClientCommand } = require('@twilio/cli-core').baseCommands;
 const { TwilioCliError } = require('@twilio/cli-core').services.error;
+const { flags } = require("@oclif/command");
 
 const { addInfra } = require('../../infra');
 
@@ -18,7 +19,11 @@ class InfraDeploy extends TwilioClientCommand {
         `The current stack is already deployed to ${deployment}. Please switch to that profile or define a new environment`
       );
     }
-    runPulumiCommand(['up'], true, this.twilioClient);
+    let command = ['up'];
+    if (this.flags.yes) {
+      command.push("--yes");
+    }
+    runPulumiCommand(command, true, this.twilioClient);
     try {
       // Store account SID of the project used for deployment
       addInfra(this.twilioClient.accountSid, getPulumiStack(), true);
@@ -27,6 +32,16 @@ class InfraDeploy extends TwilioClientCommand {
     }
   }
 }
+
+InfraDeploy.flags = Object.assign(
+  {
+    yes: flags.boolean({
+      char: 'y',
+      description: 'Passes through the --yes option to pulumi. Deploys without interactive confirmation.'
+    })
+  },
+  TwilioClientCommand.flags
+);
 
 InfraDeploy.description =
   'Deploys and updates resources described in this directory to a Twilio project';

--- a/src/commands/infra/destroy.js
+++ b/src/commands/infra/destroy.js
@@ -1,6 +1,6 @@
 const { TwilioClientCommand } = require('@twilio/cli-core').baseCommands;
 const { TwilioCliError } = require('@twilio/cli-core').services.error;
-const { flags } = require("@oclif/command");
+const { flags } = require('@oclif/command');
 
 const { destroyInfra } = require('../../infra');
 const { runPulumiCommand, Printer } = require('../../utils');
@@ -8,11 +8,13 @@ const { runPulumiCommand, Printer } = require('../../utils');
 class InfraDestroy extends TwilioClientCommand {
   async run() {
     await super.run();
+
     let command = ['destroy'];
-    if (this.flags.yes) {
+    if (this.flags["non-interactive"]) {
       command.push("--yes");
     }
     await runPulumiCommand(command, true, this.twilioClient);
+
     try {
       destroyInfra(this.twilioClient.accountSid);
       Printer.printSuccess('Resource(s) destroyed successfully!');
@@ -24,12 +26,12 @@ class InfraDestroy extends TwilioClientCommand {
 
 InfraDestroy.flags = Object.assign(
   {
-    yes: flags.boolean({
-      char: 'y',
-      description: 'Passes through the --yes option to pulumi. Destroys without interactive confirmation.'
+    'non-interactive': flags.boolean({
+      char: 'n',
+      description: 'Destroys without interactive confirmation.',
     })
   },
-  TwilioClientCommand.flags
+  TwilioClientCommand.flags,
 );
 
 InfraDestroy.description =

--- a/src/commands/infra/destroy.js
+++ b/src/commands/infra/destroy.js
@@ -1,5 +1,6 @@
 const { TwilioClientCommand } = require('@twilio/cli-core').baseCommands;
 const { TwilioCliError } = require('@twilio/cli-core').services.error;
+const { flags } = require("@oclif/command");
 
 const { destroyInfra } = require('../../infra');
 const { runPulumiCommand, Printer } = require('../../utils');
@@ -7,7 +8,11 @@ const { runPulumiCommand, Printer } = require('../../utils');
 class InfraDestroy extends TwilioClientCommand {
   async run() {
     await super.run();
-    await runPulumiCommand(['destroy'], true, this.twilioClient);
+    let command = ['destroy'];
+    if (this.flags.yes) {
+      command.push("--yes");
+    }
+    await runPulumiCommand(command, true, this.twilioClient);
     try {
       destroyInfra(this.twilioClient.accountSid);
       Printer.printSuccess('Resource(s) destroyed successfully!');
@@ -16,6 +21,16 @@ class InfraDestroy extends TwilioClientCommand {
     }
   }
 }
+
+InfraDestroy.flags = Object.assign(
+  {
+    yes: flags.boolean({
+      char: 'y',
+      description: 'Passes through the --yes option to pulumi. Destroys without interactive confirmation.'
+    })
+  },
+  TwilioClientCommand.flags
+);
 
 InfraDestroy.description =
   'Destroy deployed resources';


### PR DESCRIPTION
This should allow use of the plugin in CICD pipelines again. I added an option --yes, such that normal operation does not result in accidental creation/destruction of stacks.